### PR TITLE
Allow nested radio buttons which aren't part of the component's group. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,10 @@ module.exports = React.createClass({
             return;
         }
 
+        if(!event.target.getAttribute('name') == this.props.name){
+            return;
+        }
+
         fn(value, event)
 
         if (this.props.value == null) {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = React.createClass({
 
     setRadioNames: function () {
         this.forEachRadio(function (radio) {
-            radio.setAttribute('name', this.props.name)
+            if ( ! radio.getAttribute("name") ) radio.setAttribute('name', this.props.name);
         })
     },
 

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ module.exports = React.createClass({
             return;
         }
 
-        if(!event.target.getAttribute('name') == this.props.name){
+        if(event.target.getAttribute('name') != this.props.name){
             return;
         }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-simple-radio-group",
   "version": "0.1.3",
   "description": "A React mixin for linking form fields to a deep structure of data within the component's state.",
-  "main": "NestLinkedStateMixin.js",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
For example, imagine have a form with 4 rows. Each row has a radio at the start e.g. 

(+) Option Row 1
(  ) Option Row 2
(  ) Option Row 3
(  ) Option Row 4 

Now you want to put a sub-option on one row

(+) Option Row 1
(  ) Option Row 2
(  ) Option Row 3 - Sub Option A ( ) Sub Option B (+) 
(  ) Option Row 4 

You want to vary the Sub Options independently from the main options. 

Before this PR this isn't possible because the component renames every single radio between the tags. 

This PR means it won't rename radios if a name is explicitly defined - so you can 'opt out' of the group. 

Also - now the component will only react to change events on the radios with the correct name. 

Another nice feature would be the ability to nest radio groups. I don't know enough about your code and React to implement this at present. 